### PR TITLE
Add icon property to webchat channel settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+ - Optional `'icon'` property to `webchat-channel-settings` object property.
+
 ## [2.2.0] - 2018-09-03
 
 ### Added

--- a/bot.schema.d.ts
+++ b/bot.schema.d.ts
@@ -153,7 +153,9 @@ export declare namespace BotsSchema {
     export type BotChannelSettings =
         | ApiChannelSettings
         | WebchatChannelSettings
-        | FacebookChannelSettings;
+        | FacebookChannelSettings
+        | KikChannelSettings
+        | SlackChannelSettings;
 
     export interface BotConfig {
         name: string;
@@ -306,6 +308,7 @@ export declare namespace BotsSchema {
         awsVoice?: AwsPollyVoice;
         awsRegion?: AwsRegionPolly;
         awsCredentials?: AwsCredentials;
+        icon?: string | null;
     }
     /**
      * This interface was referenced by `BotConfig`'s JSON-Schema

--- a/bot.schema.json
+++ b/bot.schema.json
@@ -259,7 +259,8 @@
                 "authToken": { "type": "string" },
                 "awsVoice": { "$ref": "#/definitions/aws-polly-voice" },
                 "awsRegion": { "$ref": "#/definitions/aws-region-polly" },
-                "awsCredentials": { "$ref": "#/definitions/aws-credentials" }
+                "awsCredentials": { "$ref": "#/definitions/aws-credentials" },
+                "icon": { "type": [ "string", "null" ] }
             },
             "required": [ "authToken" ],
             "additionalProperties": false


### PR DESCRIPTION
Adds `icon` property to webchat channel settings.

Doesn't have to be released with a new version right away.